### PR TITLE
feat(articles): dark bg fixes, cross-links, article page polish

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -32,9 +32,6 @@ h6 {
 
 html,
 body {
-  @apply bg-white dark:bg-gray-950;
-
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-  }
+  @apply bg-black text-white;
+  color-scheme: dark;
 }

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -12,7 +12,7 @@ const Nav: React.FC = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   return (
-    <div className="flex items-center justify-between p-4 flex-wrap bg-skin-base text-skin-base">
+    <div className="flex items-center justify-between p-4 flex-wrap bg-black text-white">
       <Link
         to="/"
         className="text-2xl font-black font-palette-blueslate tracking-wide transform hover:scale-105 transition-transform duration-200"

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -44,7 +44,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           crossOrigin="anonymous"
         />
       </head>
-      <body>
+      <body className="bg-black text-white">
         {children}
         <ScrollRestoration />
         <Scripts />

--- a/app/routes/5-ways-ai-can-help-farmland-restoration.tsx
+++ b/app/routes/5-ways-ai-can-help-farmland-restoration.tsx
@@ -78,7 +78,10 @@ const FarmlandRestorationPage = () => {
         <section className="mb-8">
           <h2 className="text-left text-lg tracking-tight sm:text-2xl lg:text-3xl font-serif font-bold mb-4">Introduction</h2>
           <p className="mt-2 text-left text-lg tracking-tight sm:text-xl lg:text-2xl font-serif">
-            Artificial Intelligence (AI) offers powerful tools to address the challenges of farmland degradation and promote restoration efforts. By analyzing complex data and providing actionable insights, AI can significantly contribute to sustainable agriculture and the preservation of vital soil resources. Here are five key ways AI is making a difference:
+            Artificial Intelligence (AI) offers powerful tools to address the challenges of farmland degradation and promote restoration efforts — the{" "}
+            <a href="https://www.fao.org/soils-portal/en/" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">FAO Soils Portal</a>
+            {" "}documents how rapidly arable soil is being lost worldwide. By analyzing complex data and providing actionable insights, AI can significantly contribute to sustainable agriculture and the preservation of vital soil resources. For a parallel example of AI optimizing real-world pipelines, see our case study on{" "}
+            <Link to="/databricks-dspy-jetblue-ai-chatbot" className="text-blue-600 underline">how JetBlue applied DSPy with Databricks</Link>. Here are five key ways AI is making a difference:
           </p>
         </section>
 

--- a/app/routes/5-ways-to-enhance-rag-efficiency-with-dspy.tsx
+++ b/app/routes/5-ways-to-enhance-rag-efficiency-with-dspy.tsx
@@ -17,8 +17,8 @@ export default function Article12() {
         <div>
           {" "}
           <p className="text-left font-serif text-lg font-bold tracking-tight sm:text-2xl lg:text-3xl">
-            {" "}  DSPy is a versatile toolkit for information retrieval and prompt engineering. It can be thought of as a prompting language. It can leverage various techniques to retrieve relevant documents efficiently. Let’s explore five key approaches that make Retrieval Augmented Generation easier and less bloated!
-       
+            {" "}  <a href="https://dspy.ai" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">DSPy</a> is a versatile toolkit for information retrieval and prompt engineering. It can be thought of as a prompting language. It can leverage various techniques to retrieve relevant documents efficiently. If you are new to the underlying pattern, start with our primer on <Link to="/what-is-rag" className="text-blue-600 underline">what RAG actually is</Link>, then come back here. Let’s explore five key approaches that make Retrieval Augmented Generation easier and less bloated!
+
           </p>
           <br />
           <p className="text-left text-lg tracking-tight sm:text-2xl lg:text-3xl font-serif font-bold">

--- a/app/routes/ai-articles.tsx
+++ b/app/routes/ai-articles.tsx
@@ -4,6 +4,12 @@ export const meta: MetaFunction = () => {
   return [
     { title: "Ai Articles" },
     { name: "description", content: "List of Ai Articles for the Publication." },
+    {
+      title: "SnapState: Keeping AI Agent Workflows Alive Between Sessions",
+      description: "Discover SnapState, a simple yet powerful tool for persisting AI agent workflow state, ensuring continuity and reliability in your AI applications.",
+      link: "/snapstate-persistent-state-for-ai-agent-workflows",
+      image: "/snapstate-persistent-state-for-ai-agent-workflows.jpg"
+    },
   ];
 };
 
@@ -135,23 +141,29 @@ export default function AiArticles() {
       link: "/weirdinternetfacts",
       image: "/fish1.png"
     },
+    {
+      title: "Your First Pentest: A Practical Intro Using Free Tools",
+      description: "A hands-on introduction to penetration testing using only free, open-source tools — DVWA, Nmap, Burp Suite Community, SQLMap, and Nikto. No vendor lock-in.",
+      link: "/first-pentest-free-tools-intro",
+      image: "/first-pentest-free-tools-intro.jpg"
+    },
   ];
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-4xl font-bold text-center mb-8">Articles</h1>
+      <h1 className="text-4xl font-bold text-center mb-8 text-white">Articles</h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
         {articles.map((article) => (
-          <div key={article.link} className="bg-white rounded-lg shadow-md overflow-hidden transform transition duration-300 hover:scale-105">
+          <div key={article.link} className="bg-gray-900 rounded-lg shadow-md overflow-hidden transform transition duration-300 hover:scale-105 hover:bg-gray-800">
             <a href={article.link} className="block">
-              <img 
-                src={article.image} 
+              <img
+                src={article.image}
                 alt={article.title}
                 className="w-full h-48 object-cover"
               />
               <div className="p-4">
-                <h2 className="text-xl font-semibold mb-2">{article.title}</h2>
-                <p className="text-gray-600 text-sm">{article.description}</p>
+                <h2 className="text-xl font-semibold mb-2 text-white">{article.title}</h2>
+                <p className="text-gray-400 text-sm">{article.description}</p>
               </div>
             </a>
           </div>

--- a/app/routes/ai-articles.tsx
+++ b/app/routes/ai-articles.tsx
@@ -4,12 +4,6 @@ export const meta: MetaFunction = () => {
   return [
     { title: "Ai Articles" },
     { name: "description", content: "List of Ai Articles for the Publication." },
-    {
-      title: "SnapState: Keeping AI Agent Workflows Alive Between Sessions",
-      description: "Discover SnapState, a simple yet powerful tool for persisting AI agent workflow state, ensuring continuity and reliability in your AI applications.",
-      link: "/snapstate-persistent-state-for-ai-agent-workflows",
-      image: "/snapstate-persistent-state-for-ai-agent-workflows.jpg"
-    },
   ];
 };
 
@@ -140,6 +134,12 @@ export default function AiArticles() {
       description: "Dive into a collection of bizarre and fascinating facts from the internet, guaranteed to surprise and entertain.",
       link: "/weirdinternetfacts",
       image: "/fish1.png"
+    },
+    {
+      title: "SnapState: Keeping AI Agent Workflows Alive Between Sessions",
+      description: "Discover SnapState, a simple yet powerful tool for persisting AI agent workflow state, ensuring continuity and reliability in your AI applications.",
+      link: "/snapstate-persistent-state-for-ai-agent-workflows",
+      image: "/snapstate-persistent-state-for-ai-agent-workflows.jpg"
     },
     {
       title: "Your First Pentest: A Practical Intro Using Free Tools",

--- a/app/routes/archive.$type.tsx
+++ b/app/routes/archive.$type.tsx
@@ -80,16 +80,16 @@ function StructuredFields({
       {fields.map(([k, v]) => (
         <div
           key={k}
-          className="rounded-xl border border-gray-200 bg-white/70 backdrop-blur p-4 shadow-sm"
+          className="rounded-xl border border-gray-700 bg-gray-900 backdrop-blur p-4 shadow-sm"
         >
-          <dt className="text-[10px] font-bold uppercase tracking-widest text-purple-600 mb-1">
+          <dt className="text-[10px] font-bold uppercase tracking-widest text-purple-400 mb-1">
             {k.replace(/_/g, " ")}
           </dt>
-          <dd className="text-sm text-gray-800 break-words">
+          <dd className="text-sm text-gray-200 wrap-break-word">
             {typeof v === "string" || typeof v === "number" ? (
               String(v)
             ) : (
-              <pre className="whitespace-pre-wrap font-mono text-[11px] text-gray-700 max-h-48 overflow-auto">
+              <pre className="whitespace-pre-wrap font-mono text-[11px] text-gray-400 max-h-48 overflow-auto">
                 {JSON.stringify(v, null, 2)}
               </pre>
             )}
@@ -114,10 +114,10 @@ export default function ArchiveTypePage({
   const gradient = TYPE_GRADIENTS[meta.id] ?? "from-slate-600 to-slate-800";
 
   return (
-    <main className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-50">
+    <main className="min-h-screen bg-black">
       {/* Hero */}
       <header className="relative overflow-hidden border-b border-gray-200">
-        <div className={`absolute inset-0 bg-gradient-to-br ${gradient}`} />
+        <div className={`absolute inset-0 bg-linear-to-br ${gradient}`} />
         <img
           src={HERO_IMAGE}
           alt=""
@@ -154,7 +154,7 @@ export default function ArchiveTypePage({
       </header>
 
       {/* Type tabs */}
-      <nav className="border-b border-gray-200 bg-white/80 backdrop-blur sticky top-0 z-10">
+      <nav className="border-b border-gray-800 bg-black/90 backdrop-blur sticky top-0 z-10">
         <div className="container mx-auto px-4">
           <div className="flex gap-1 overflow-x-auto py-3 scrollbar-hide">
             {types.map((t) => (
@@ -163,8 +163,8 @@ export default function ArchiveTypePage({
                 to={`/archive/${t.id}`}
                 className={`whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-bold uppercase tracking-wider transition-colors ${
                   t.id === meta.id
-                    ? "bg-gradient-to-r from-purple-600 to-pink-600 text-white shadow-md"
-                    : "text-gray-600 hover:bg-gray-100"
+                    ? "bg-linear-to-r from-purple-600 to-pink-600 text-white shadow-md"
+                    : "text-gray-400 hover:bg-gray-800"
                 }`}
               >
                 {t.label}
@@ -176,34 +176,34 @@ export default function ArchiveTypePage({
 
       <section className="container mx-auto px-4 py-10 sm:py-14 max-w-4xl">
         {!article || !raw ? (
-          <div className="rounded-2xl border-2 border-dashed border-gray-300 bg-white p-12 text-center">
+          <div className="rounded-2xl border-2 border-dashed border-gray-700 bg-gray-900 p-12 text-center">
             <div className="text-5xl mb-4">📭</div>
-            <h2 className="text-xl font-bold text-gray-900 mb-2">
+            <h2 className="text-xl font-bold text-white mb-2">
               No {meta.label.toLowerCase()} for today
             </h2>
-            <p className="text-gray-600">
+            <p className="text-gray-400">
               The pipeline hasn't generated this article type yet. Check back
               later or pick another flavor.
             </p>
           </div>
         ) : (
           <>
-            <article className="rounded-2xl bg-white border border-gray-200 shadow-md p-6 sm:p-10">
+            <article className="rounded-2xl bg-gray-900 border border-gray-700 shadow-md p-6 sm:p-10">
               {article.content ? (
-                <div className="prose prose-lg max-w-none">
+                <div className="prose prose-invert prose-lg max-w-none">
                   {article.content.split(/\n{2,}/).map((para, i) => (
                     <p key={i}>{para.trim()}</p>
                   ))}
                 </div>
               ) : (
-                <p className="text-gray-500 italic">
+                <p className="text-gray-400 italic">
                   No prose body for this article — see structured data below.
                 </p>
               )}
             </article>
 
-            <details className="mt-8 rounded-xl border border-gray-200 bg-white/60 backdrop-blur p-4">
-              <summary className="cursor-pointer text-sm font-bold text-gray-700">
+            <details className="mt-8 rounded-xl border border-gray-700 bg-gray-900/60 backdrop-blur p-4">
+              <summary className="cursor-pointer text-sm font-bold text-gray-300">
                 Show structured fields ({Object.keys(raw.data).length})
               </summary>
               <StructuredFields

--- a/app/routes/archive._index.tsx
+++ b/app/routes/archive._index.tsx
@@ -53,7 +53,7 @@ export default function ArchiveIndex({
   }
 
   return (
-    <main className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-50">
+    <main className="min-h-screen bg-black">
       <header className="relative overflow-hidden border-b border-gray-200">
         <div className="absolute inset-0 bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-600" />
         <div className="absolute inset-0 opacity-30 bg-[radial-gradient(circle_at_20%_20%,rgba(255,255,255,0.4),transparent_50%),radial-gradient(circle_at_80%_60%,rgba(255,255,255,0.3),transparent_50%)]" />

--- a/app/routes/articles.$slug.tsx
+++ b/app/routes/articles.$slug.tsx
@@ -81,17 +81,17 @@ function AiSummaryLayout({ article }: { article: import("~/types/article").Fires
 
       {/* Snapshot strip */}
       <div className="grid grid-cols-3 gap-3 mb-8">
-        <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-center">
+        <div className="rounded-lg border border-gray-700 bg-gray-900 px-4 py-3 text-center">
           <div className="text-xs uppercase tracking-wide text-gray-400 mb-1">Regime</div>
-          <div className="font-semibold text-gray-800 text-sm">{ai.macro_regime}</div>
+          <div className="font-semibold text-white text-sm">{ai.macro_regime}</div>
         </div>
-        <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-center">
+        <div className="rounded-lg border border-gray-700 bg-gray-900 px-4 py-3 text-center">
           <div className="text-xs uppercase tracking-wide text-gray-400 mb-1">Tone</div>
           <div className={`font-semibold text-sm capitalize ${toneColor(ai.market_tone)}`}>
             {ai.market_tone}
           </div>
         </div>
-        <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-center">
+        <div className="rounded-lg border border-gray-700 bg-gray-900 px-4 py-3 text-center">
           <div className="text-xs uppercase tracking-wide text-gray-400 mb-1">Breadth</div>
           <div className={`font-semibold text-sm ${breadthColor(ai.breadth_pct)}`}>
             {ai.breadth_pct > 0 ? "+" : ""}{ai.breadth_pct.toFixed(1)}%
@@ -103,21 +103,21 @@ function AiSummaryLayout({ article }: { article: import("~/types/article").Fires
       {(ai.leading_sectors.length > 0 || ai.lagging_sectors.length > 0) && (
         <div className="flex gap-4 mb-8">
           {ai.leading_sectors.length > 0 && (
-            <div className="flex-1 rounded-lg border border-green-200 bg-green-50 px-4 py-3">
-              <div className="text-xs uppercase tracking-wide text-green-600 font-semibold mb-2">Leading</div>
+            <div className="flex-1 rounded-lg border border-green-800 bg-green-950 px-4 py-3">
+              <div className="text-xs uppercase tracking-wide text-green-400 font-semibold mb-2">Leading</div>
               <div className="flex flex-wrap gap-1">
                 {ai.leading_sectors.map((s) => (
-                  <span key={s} className="text-xs bg-green-100 text-green-800 rounded-full px-2 py-0.5">{s}</span>
+                  <span key={s} className="text-xs bg-green-900 text-green-300 rounded-full px-2 py-0.5">{s}</span>
                 ))}
               </div>
             </div>
           )}
           {ai.lagging_sectors.length > 0 && (
-            <div className="flex-1 rounded-lg border border-red-200 bg-red-50 px-4 py-3">
-              <div className="text-xs uppercase tracking-wide text-red-600 font-semibold mb-2">Lagging</div>
+            <div className="flex-1 rounded-lg border border-red-800 bg-red-950 px-4 py-3">
+              <div className="text-xs uppercase tracking-wide text-red-400 font-semibold mb-2">Lagging</div>
               <div className="flex flex-wrap gap-1">
                 {ai.lagging_sectors.map((s) => (
-                  <span key={s} className="text-xs bg-red-100 text-red-800 rounded-full px-2 py-0.5">{s}</span>
+                  <span key={s} className="text-xs bg-red-900 text-red-300 rounded-full px-2 py-0.5">{s}</span>
                 ))}
               </div>
             </div>
@@ -155,7 +155,7 @@ function StandardLayout({ article }: { article: import("~/types/article").Firest
       </div>
 
       <h1 className="text-3xl font-bold mb-4 lg:text-4xl">{article.title}</h1>
-      <p className="text-lg text-gray-600 mb-8">{article.summary}</p>
+      <p className="text-lg text-gray-300 mb-8">{article.summary}</p>
 
       {article.contentFormat === "html" ? (
         <div
@@ -175,10 +175,10 @@ function StandardLayout({ article }: { article: import("~/types/article").Firest
       {article.extreme_pair && (
         <aside className={`mt-8 border rounded-lg px-4 py-3 text-sm ${
           article.extreme_pair.signal === "divergence"
-            ? "border-red-300 bg-red-50 text-red-800"
+            ? "border-red-800 bg-red-950 text-red-300"
             : article.extreme_pair.signal === "agreement"
-            ? "border-green-300 bg-green-50 text-green-800"
-            : "border-gray-300 bg-gray-50 text-gray-700"
+            ? "border-green-800 bg-green-950 text-green-300"
+            : "border-gray-700 bg-gray-900 text-gray-300"
         }`}>
           <div className="font-semibold uppercase tracking-wide text-xs mb-1">
             {article.extreme_pair.signal} — {article.extreme_pair.pair_id}
@@ -215,11 +215,11 @@ export default function ArticlePage({ loaderData }: { loaderData: LoaderData }) 
               <Link
                 key={c.slug}
                 to={`/articles/${c.slug}`}
-                className="block rounded-lg border border-gray-200 px-4 py-3 hover:border-purple-300 hover:bg-purple-50 transition-colors"
+                className="block rounded-lg border border-gray-700 bg-gray-900 px-4 py-3 hover:border-purple-600 hover:bg-gray-800 transition-colors"
               >
-                <div className="text-xs font-semibold text-purple-500 mb-1">{c.category}</div>
-                <div className="font-medium text-gray-900 text-sm leading-snug line-clamp-2">{c.title}</div>
-                <div className="text-xs text-gray-500 mt-1 line-clamp-2">{c.summary}</div>
+                <div className="text-xs font-semibold text-purple-400 mb-1">{c.category}</div>
+                <div className="font-medium text-white text-sm leading-snug line-clamp-2">{c.title}</div>
+                <div className="text-xs text-gray-400 mt-1 line-clamp-2">{c.summary}</div>
               </Link>
             ))}
           </div>

--- a/app/routes/articles.$slug.tsx
+++ b/app/routes/articles.$slug.tsx
@@ -45,15 +45,15 @@ type LoaderData = {
 
 function toneColor(tone: string): string {
   const t = tone.toLowerCase();
-  if (t === "bullish" || t === "positive") return "text-green-600";
-  if (t === "bearish" || t === "negative") return "text-red-600";
-  return "text-yellow-600";
+  if (t === "bullish" || t === "positive") return "text-green-400";
+  if (t === "bearish" || t === "negative") return "text-red-400";
+  return "text-yellow-400";
 }
 
 function breadthColor(pct: number): string {
-  if (pct > 5) return "text-green-600";
-  if (pct < -5) return "text-red-600";
-  return "text-yellow-600";
+  if (pct > 5) return "text-green-400";
+  if (pct < -5) return "text-red-400";
+  return "text-yellow-400";
 }
 
 function AiSummaryLayout({ article }: { article: import("~/types/article").FirestoreArticle }) {

--- a/app/routes/correlations-archive.tsx
+++ b/app/routes/correlations-archive.tsx
@@ -111,25 +111,25 @@ function ArchiveCard({ article, index }: { article: ArticleCard; index: number }
   return (
     <Link
       to={`/articles/${article.slug}`}
-      className="group relative flex flex-col overflow-hidden rounded-xl bg-white border border-gray-200 shadow-sm transition-all duration-300 hover:shadow-xl hover:-translate-y-1 hover:border-transparent"
+      className="group relative flex flex-col overflow-hidden rounded-xl bg-gray-900 border border-gray-700 shadow-sm transition-all duration-300 hover:shadow-xl hover:-translate-y-1 hover:border-purple-600"
     >
       <div className={`h-2 bg-gradient-to-r ${gradient}`} />
       <div className="flex flex-col p-5 flex-1">
         <div className="flex items-center justify-between mb-3">
-          <span className="rounded-full bg-gradient-to-r from-purple-50 to-pink-50 border border-purple-100 px-2.5 py-0.5 text-[11px] font-bold uppercase tracking-wide text-purple-700">
+          <span className="rounded-full bg-purple-900 border border-purple-700 px-2.5 py-0.5 text-[11px] font-bold uppercase tracking-wide text-purple-300">
             {article.category}
           </span>
-          <time className="text-[11px] font-medium text-gray-500" title={formatDate(article.publishedAt)}>
+          <time className="text-[11px] font-medium text-gray-400" title={formatDate(article.publishedAt)}>
             {relativeTime(article.publishedAt)}
           </time>
         </div>
-        <h3 className="text-lg font-bold text-gray-900 line-clamp-2 mb-2 group-hover:text-transparent group-hover:bg-clip-text group-hover:bg-gradient-to-r group-hover:from-purple-600 group-hover:to-pink-600 transition-colors">
+        <h3 className="text-lg font-bold text-white line-clamp-2 mb-2 group-hover:text-transparent group-hover:bg-clip-text group-hover:bg-gradient-to-r group-hover:from-purple-400 group-hover:to-pink-400 transition-colors">
           {article.title}
         </h3>
-        <p className="text-sm text-gray-600 line-clamp-3 flex-1">{article.summary}</p>
-        <div className="mt-4 pt-3 border-t border-gray-100 flex items-center justify-between">
-          <span className="text-xs text-gray-400 font-mono">#{String(index + 1).padStart(3, "0")}</span>
-          <span className="text-xs font-bold text-purple-600 inline-flex items-center gap-1">
+        <p className="text-sm text-gray-400 line-clamp-3 flex-1">{article.summary}</p>
+        <div className="mt-4 pt-3 border-t border-gray-700 flex items-center justify-between">
+          <span className="text-xs text-gray-500 font-mono">#{String(index + 1).padStart(3, "0")}</span>
+          <span className="text-xs font-bold text-purple-400 inline-flex items-center gap-1">
             Read
             <span className="transition-transform group-hover:translate-x-1">→</span>
           </span>
@@ -149,7 +149,7 @@ export default function CorrelationsArchive({
   const rest = articles.slice(1);
 
   return (
-    <main className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-50">
+    <main className="min-h-screen bg-black">
       <header className="relative overflow-hidden border-b border-gray-200">
         <div className="absolute inset-0 bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-600" />
         <img
@@ -200,12 +200,12 @@ export default function CorrelationsArchive({
 
       <section className="container mx-auto px-4 py-10 sm:py-14">
         {articles.length === 0 ? (
-          <div className="rounded-2xl border-2 border-dashed border-gray-300 bg-white p-12 text-center">
+          <div className="rounded-2xl border-2 border-dashed border-gray-700 bg-gray-900 p-12 text-center">
             <div className="text-5xl mb-4">📊</div>
-            <h2 className="text-xl font-bold text-gray-900 mb-2">
+            <h2 className="text-xl font-bold text-white mb-2">
               No correlation articles yet
             </h2>
-            <p className="text-gray-600 max-w-md mx-auto">
+            <p className="text-gray-400 max-w-md mx-auto">
               The daily story pipeline hasn't published any articles to the cache.
               Check back after the next refresh.
             </p>
@@ -227,10 +227,10 @@ export default function CorrelationsArchive({
             {rest.length > 0 && (
               <>
                 <div className="flex items-baseline justify-between mb-6">
-                  <h2 className="text-2xl sm:text-3xl font-extrabold text-gray-900">
+                  <h2 className="text-2xl sm:text-3xl font-extrabold text-white">
                     Other articles today
                   </h2>
-                  <span className="text-sm text-gray-500 font-medium">
+                  <span className="text-sm text-gray-400 font-medium">
                     {rest.length} {rest.length === 1 ? "entry" : "entries"}
                   </span>
                 </div>

--- a/app/routes/create-your-own-huggingface-space-easy.tsx
+++ b/app/routes/create-your-own-huggingface-space-easy.tsx
@@ -32,7 +32,10 @@ export default function Article5() {
         />
         <div>
           <p className="text-left font-serif text-lg font-bold tracking-tight sm:text-2xl lg:text-3xl">
-            Hugging Face Spaces offer a simple way to host not just ML demo apps directly on your profile or your organization’s profile, but really any Python code you want.
+            <a href="https://huggingface.co/spaces" target="_blank" rel="noopener noreferrer" className="text-blue-500">Hugging Face Spaces</a>
+            {" "}offer a simple way to host not just ML demo apps directly on your profile or your organization’s profile, but really any Python code you want. If you are deploying a model that uses RAG patterns, our primer on{" "}
+            <Link to="/what-is-rag" className="text-blue-500">What is RAG</Link>
+            {" "}pairs well with this guide.
           </p>
           <br />
           <p className="text-left font-serif text-lg font-bold tracking-tight sm:text-2xl lg:text-3xl">

--- a/app/routes/databricks-dspy-jetblue-ai-chatbot.tsx
+++ b/app/routes/databricks-dspy-jetblue-ai-chatbot.tsx
@@ -40,8 +40,8 @@ export default function Article12() {
             <a href="https://arxiv.org/abs/2310.03714" className="text-blue-500"> here</a>.
           </p>
           <p className="text-left text-lg tracking-tight sm:text-xl lg:text-2xl font-serif">
-            DSPy allows developers to construct complex LLM pipelines that adapt dynamically to evolving requirements, making traditional manual prompt-tuning redundant. For more on its retrieval capabilities, check out
-            <a href="https://dspy.ai" className="text-blue-500"> Five Ways to Do RAG with DSPy</a>.
+            DSPy allows developers to construct complex LLM pipelines that adapt dynamically to evolving requirements, making traditional manual prompt-tuning redundant. For more on its retrieval capabilities, check out our deep-dive on{" "}
+            <Link to="/5-ways-to-enhance-rag-efficiency-with-dspy" className="text-blue-500">Five Ways to Enhance RAG Efficiency with DSPy</Link>.
           </p>
           <br />
           <p className="text-left text-lg tracking-tight sm:text-xl lg:text-2xl font-serif">

--- a/app/routes/dspy101.tsx
+++ b/app/routes/dspy101.tsx
@@ -15,7 +15,12 @@ const RemixPage = () => {
       <header className="bg-blue-600 text-white py-6 shadow-lg">
         <div className="container mx-auto px-4">
           <h1 className="text-3xl font-bold">DSPy 101 Tutorial: Prompting Guide</h1>
-          <p className="mt-2">Simplify LLM-powered applications with DSPy.</p>
+          <p className="mt-2">
+            Simplify LLM-powered applications with{" "}
+            <a href="https://dspy.ai" target="_blank" rel="noopener noreferrer" className="underline">DSPy</a>.
+            For a deeper dive on retrieval patterns, see our companion piece on{" "}
+            <Link to="/5-ways-to-enhance-rag-efficiency-with-dspy" className="underline">Five Ways to Enhance RAG Efficiency with DSPy</Link>.
+          </p>
         </div>
       </header>
       <section className="mb-8">

--- a/app/routes/introduction-to-neural-networks.tsx
+++ b/app/routes/introduction-to-neural-networks.tsx
@@ -44,7 +44,10 @@ export default function ArticleNN() {
           </p>
           <p className="text-left text-lg tracking-tight sm:text-xl lg:text-2xl font-serif">
             PyTorch has become the go-to framework for neural network research and production deployment. Its dynamic nature allows for easy debugging and experimentation, while its comprehensive ecosystem includes tools for computer vision (torchvision), natural language processing (torchtext), and audio processing (torchaudio). Get started with PyTorch by exploring their comprehensive{" "}
-            <a href="https://pytorch.org/docs/stable/index.html" className="text-blue-500">documentation</a>.
+            <a href="https://pytorch.org/docs/stable/index.html" target="_blank" rel="noopener noreferrer" className="text-blue-500">documentation</a>,
+            {" "}then move on to our companion guide on{" "}
+            <Link to="/10-essential-pytorch-elements-in-a-rnn" className="text-blue-500">10 Essential PyTorch Elements in an RNN</Link>
+            {" "}for the sequence-modeling building blocks.
           </p>
           <br />
           <p className="text-left text-lg tracking-tight sm:text-xl lg:text-2xl font-serif font-bold">

--- a/app/routes/what-is-rag.tsx
+++ b/app/routes/what-is-rag.tsx
@@ -73,7 +73,10 @@ const RemixPage = () => {
         <section className="mb-8">
           <h2 className="text-left text-lg tracking-tight sm:text-2xl lg:text-3xl font-serif font-bold mb-4">Introduction</h2>
           <p className="mt-2 text-left text-lg tracking-tight sm:text-xl lg:text-2xl font-serif">
-            Retrieval-Augmented Generation (RAG) is an AI framework that enhances the outputs of large language models (LLMs) by incorporating information from external sources. It combines the generative capabilities of LLMs with the retrieval capabilities of traditional information retrieval. This combination allows RAG to access and reference information outside the LLMs' training data, leading to more accurate, up-to-date, and contextually relevant responses.
+            Retrieval-Augmented Generation (RAG) is an AI framework — originally proposed in a{" "}
+            <a href="https://arxiv.org/abs/2005.11401" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">2020 Facebook AI paper</a>
+            {" "}— that enhances the outputs of large language models (LLMs) by incorporating information from external sources. It combines the generative capabilities of LLMs with the retrieval capabilities of traditional information retrieval. This combination allows RAG to access and reference information outside the LLMs&apos; training data, leading to more accurate, up-to-date, and contextually relevant responses. For a hands-on follow-up, see our companion piece on{" "}
+            <Link to="/5-ways-to-enhance-rag-efficiency-with-dspy" className="text-blue-600 underline">Five Ways to Enhance RAG Efficiency with DSPy</Link>.
           </p>
         </section>
 


### PR DESCRIPTION
## Summary

- Fix navbar white background — `bg-skin-base` was an undefined CSS variable resolving to white; replaced with `bg-black text-white`
- Set `bg-black text-white` on `<body>` in root.tsx to prevent margin/gap bleed
- Force always-dark background in `app.css` (remove light/dark media query)
- Cross-links and external references added across article routes
- Polish on archive, correlations, ai-articles, and article slug pages

## Test plan

- [ ] Navbar background is black on all pages
- [ ] No white margins or gaps visible between sections
- [ ] Article pages load without layout regressions
- [ ] `npm run typecheck` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)